### PR TITLE
@nogc-ify druntime exception handling; make _d_exception refcounted

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -673,4 +673,73 @@ else
         onHiddenFuncError(o);
     }
 }
+
+    version (unittest)
+    {
+        struct MemoryBlock
+        {
+        @nogc:
+            import core.stdc.stdlib : malloc, free;
+            void* p;
+            this(uint size) { p = malloc(size); }
+            ~this() { free(p); }
+        }
+
+        // weka-io: test throwing of static exceptions
+        unittest
+        {
+            void throwStaticException() @nogc
+            {
+                static exception = new UnicodeException("Testing 123", 0);
+                throw exception;
+            }
+
+            try
+            {
+                try
+                {
+                    auto block = MemoryBlock(64);
+                    throwStaticException();
+                }
+                catch (Exception e)
+                {
+                    assert(e.msg == "Testing 123");
+                    e.msg ~= '4';
+                    throw e;
+                }
+            }
+            catch (Exception e)
+            {
+                assert(e.msg == "Testing 1234");
+            }
+        }
+
+        // weka-io: test throwing of non-static exceptions
+        unittest
+        {
+            void throwNewException()
+            {
+                throw new UnicodeException("Testing 123", 0);
+            }
+
+            try
+            {
+                try
+                {
+                    auto block = MemoryBlock(64);
+                    throwNewException();
+                }
+                catch (Exception e)
+                {
+                    assert(e.msg == "Testing 123");
+                    e.msg ~= '4';
+                    throw e;
+                }
+            }
+            catch (Exception e)
+            {
+                assert(e.msg == "Testing 1234");
+            }
+        }
+    }
 }

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -115,10 +115,10 @@ private
 
     extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
 
-    extern (C) void gc_addRoot( in void* p ) nothrow;
+    extern (C) void gc_addRoot( in void* p ) nothrow @nogc;
     extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow;
 
-    extern (C) void gc_removeRoot( in void* p ) nothrow;
+    extern (C) void gc_removeRoot( in void* p ) nothrow @nogc;
     extern (C) void gc_removeRange( in void* p ) nothrow;
     extern (C) void gc_runFinalizers( in void[] segment );
 }
@@ -679,7 +679,7 @@ struct GC
      * }
      * ---
      */
-    static void addRoot( in void* p ) nothrow /* FIXME pure */
+    static void addRoot( in void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_addRoot( p );
     }
@@ -693,7 +693,7 @@ struct GC
      * Params:
      *  p = A pointer into a GC-managed memory block or null.
      */
-    static void removeRoot( in void* p ) nothrow /* FIXME pure */
+    static void removeRoot( in void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRoot( p );
     }

--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -13,7 +13,7 @@
 module core.stdc.stdarg;
 
 @system:
-//@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
+@nogc:
 
 version ( PPC ) version = AnyPPC;
 version ( PPC64 ) version = AnyPPC;

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -128,13 +128,13 @@ class Mutex :
      * Throws:
      *  SyncError on error.
      */
-    @trusted void lock()
+    @trusted void lock() @nogc
     {
         lock_nothrow();
     }
 
     // undocumented function for internal use
-    final void lock_nothrow() nothrow @trusted
+    final void lock_nothrow() nothrow @trusted @nogc
     {
         version( Windows )
         {
@@ -142,9 +142,10 @@ class Mutex :
         }
         else version( Posix )
         {
+            static exception = new SyncError( "Unable to lock mutex" );
             int rc = pthread_mutex_lock( &m_hndl );
             if( rc )
-                throw new SyncError( "Unable to lock mutex" );
+                throw exception;
         }
     }
 
@@ -155,13 +156,13 @@ class Mutex :
      * Throws:
      *  SyncError on error.
      */
-    @trusted void unlock()
+    @trusted void unlock() @nogc
     {
         unlock_nothrow();
     }
 
     // undocumented function for internal use
-    final void unlock_nothrow() nothrow @trusted
+    final void unlock_nothrow() nothrow @trusted @nogc
     {
         version( Windows )
         {
@@ -169,9 +170,10 @@ class Mutex :
         }
         else version( Posix )
         {
+            static exception = new SyncError( "Unable to unlock mutex" );
             int rc = pthread_mutex_unlock( &m_hndl );
             if( rc )
-                throw new SyncError( "Unable to unlock mutex" );
+                throw exception;
         }
     }
 

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -450,9 +450,9 @@ version( Posix )
     int pthread_key_delete(pthread_key_t);
     int pthread_mutex_destroy(pthread_mutex_t*);
     int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
-    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(pthread_mutex_t*) @nogc;
     int pthread_mutex_trylock(pthread_mutex_t*);
-    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(pthread_mutex_t*) @nogc;
     int pthread_mutexattr_destroy(pthread_mutexattr_t*);
     int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
     int pthread_once(pthread_once_t*, void function());

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -244,12 +244,12 @@ const uint GCVERSION = 1;       // increment every time we change interface
 // This just makes Mutex final to de-virtualize member function calls.
 final class GCMutex : Mutex
 {
-    final override void lock() nothrow @trusted
+    final override void lock() nothrow @trusted @nogc
     {
         super.lock_nothrow();
     }
 
-    final override void unlock() nothrow @trusted
+    final override void unlock() nothrow @trusted @nogc
     {
         super.unlock_nothrow();
     }
@@ -1079,7 +1079,7 @@ struct GC
     /**
      * add p to list of roots
      */
-    void addRoot(void *p) nothrow
+    void addRoot(void *p) nothrow @nogc
     {
         if (!p)
         {
@@ -1095,7 +1095,7 @@ struct GC
     /**
      * remove p from list of roots
      */
-    void removeRoot(void *p) nothrow
+    void removeRoot(void *p) nothrow @nogc
     {
         if (!p)
         {
@@ -1477,7 +1477,7 @@ struct Gcx
     /**
      *
      */
-    void addRoot(void *p) nothrow
+    void addRoot(void *p) nothrow @nogc
     {
         roots.insert(Root(p));
     }
@@ -1486,7 +1486,7 @@ struct Gcx
     /**
      *
      */
-    void removeRoot(void *p) nothrow
+    void removeRoot(void *p) nothrow @nogc
     {
         roots.remove(Root(p));
     }

--- a/src/object.di
+++ b/src/object.di
@@ -126,7 +126,7 @@ class TypeInfo
     void destroy(void* p) const;
     void postblit(void* p) const;
     @property size_t talign() nothrow pure const @safe @nogc;
-    version (X86_64) int argTypes(out TypeInfo arg1, out TypeInfo arg2) @safe nothrow;
+    version (X86_64) int argTypes(out TypeInfo arg1, out TypeInfo arg2) @safe nothrow @nogc;
     @property immutable(void)* rtInfo() nothrow pure const @safe @nogc;
 }
 
@@ -159,7 +159,7 @@ class TypeInfo_Array : TypeInfo
     override @property inout(TypeInfo) next() nothrow pure inout;
     override @property uint flags() nothrow pure const;
     override @property size_t talign() nothrow pure const;
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2);
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc;
 
     TypeInfo value;
 }

--- a/src/object_.d
+++ b/src/object_.d
@@ -326,7 +326,7 @@ class TypeInfo
     /** Return internal info on arguments fitting into 8byte.
      * See X86-64 ABI 3.2.3
      */
-    version (X86_64) int argTypes(out TypeInfo arg1, out TypeInfo arg2) @safe nothrow
+    version (X86_64) int argTypes(out TypeInfo arg1, out TypeInfo arg2) @safe nothrow @nogc
     {
         arg1 = this;
         return 0;
@@ -362,7 +362,7 @@ class TypeInfo_Typedef : TypeInfo
 
     override @property size_t talign() nothrow pure const { return base.talign; }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         return base.argTypes(arg1, arg2);
     }
@@ -507,7 +507,7 @@ class TypeInfo_Array : TypeInfo
         return (void[]).alignof;
     }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         arg1 = typeid(size_t);
         arg2 = typeid(void*);
@@ -623,7 +623,7 @@ class TypeInfo_StaticArray : TypeInfo
         return value.talign;
     }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         arg1 = typeid(void*);
         return 0;
@@ -674,7 +674,7 @@ class TypeInfo_AssociativeArray : TypeInfo
         return (char[int]).alignof;
     }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         arg1 = typeid(void*);
         return 0;
@@ -705,7 +705,7 @@ class TypeInfo_Vector : TypeInfo
 
     override @property size_t talign() nothrow pure const { return 16; }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         return base.argTypes(arg1, arg2);
     }
@@ -773,7 +773,7 @@ class TypeInfo_Delegate : TypeInfo
         return dg.alignof;
     }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         arg1 = typeid(void*);
         arg2 = typeid(void*);
@@ -1092,7 +1092,7 @@ class TypeInfo_Struct : TypeInfo
 
     version (X86_64)
     {
-        override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+        override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
         {
             arg1 = m_arg1;
             arg2 = m_arg2;
@@ -1192,7 +1192,7 @@ class TypeInfo_Tuple : TypeInfo
         assert(0);
     }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         assert(0);
     }
@@ -1230,7 +1230,7 @@ class TypeInfo_Const : TypeInfo
 
     override @property size_t talign() nothrow pure const { return base.talign; }
 
-    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
+    version (X86_64) override int argTypes(out TypeInfo arg1, out TypeInfo arg2) @nogc
     {
         return base.argTypes(arg1, arg2);
     }

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -50,6 +50,7 @@ extern (C) void rt_moduleDtor();
 extern (C) void rt_moduleTlsDtor();
 extern (C) void thread_joinAll();
 extern (C) bool runModuleUnitTests();
+extern (C) size_t _d_eh_exception_structs_in_flight_count();
 
 version (OSX)
 {
@@ -197,6 +198,12 @@ extern (C) int rt_term()
 
     try
     {
+        static exceptionError = new Error(
+            "More than zero exception structs in flight!");
+
+        if (_d_eh_exception_structs_in_flight_count() != 0)
+            throw exceptionError;
+
         rt_moduleTlsDtor();
         thread_joinAll();
         rt_moduleDtor();

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -22,7 +22,7 @@ void* xrealloc(void* ptr, size_t sz)
     assert(0);
 }
 
-void* xmalloc(size_t sz) nothrow
+void* xmalloc(size_t sz) nothrow @nogc
 {
     import core.exception;
     if (auto nptr = .malloc(sz))

--- a/src/rt/util/container/treap.d
+++ b/src/rt/util/container/treap.d
@@ -32,7 +32,7 @@ nothrow:
         rand48.defaultSeed();
     }
 
-    void insert(E element)
+    void insert(E element) @nogc
     {
         root = insert(root, element);
     }
@@ -110,7 +110,7 @@ private:
     Node* root;
     Rand48 rand48;
 
-    Node* allocNode(E element)
+    Node* allocNode(E element) @nogc
     {
         Node* node = cast(Node*)common.xmalloc(Node.sizeof);
         node.left = node.right = null;
@@ -119,7 +119,7 @@ private:
         return node;
     }
 
-    Node* insert(Node* node, E element)
+    Node* insert(Node* node, E element) @nogc
     {
         if (!node)
             return allocNode(element);

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -24,19 +24,19 @@ nothrow:
         popFront();
     }
 
-    auto opCall()
+    auto opCall() @nogc
     {
         auto result = front;
         popFront();
         return result;
     }
 
-    @property uint front()
+    @property uint front() @nogc
     {
         return cast(uint)(rng_state >> 16);
     }
 
-    void popFront()
+    void popFront() @nogc
     {
         immutable ulong a = 25214903917;
         immutable ulong c = 11;


### PR DESCRIPTION
- Apply @nogc to exception handling functions, and to the druntime functions that EH depends on (`GC.*root`, `core.stdc.stdarg`, `core.sync.mutex`, etc)
- Add reference counting to _d_exception, allowing for deterministic destruction
